### PR TITLE
Add an option to control coordinate wrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ L.control.coordinates({
 	labelTemplateLng:"Longitude: {x}", //optional default "Lng: {x}"
 	enableUserInput:true, //optional default true
 	useDMS:false, //optional default false
+	wrapCoordinate:true, //optional default true
 	useLatLngOrder: true, //ordering of labels, default false-> lng-lat
 	markerType: L.marker, //optional default L.marker
 	markerProps: {}, //optional default {},

--- a/dist/Leaflet.Coordinates-0.1.5.src.js
+++ b/dist/Leaflet.Coordinates-0.1.5.src.js
@@ -19,6 +19,8 @@ L.Control.Coordinates = L.Control.extend({
 		enableUserInput: true,
 		//use Degree-Minute-Second
 		useDMS: false,
+		//should coordinate be wrapped as on earth
+		wrapCoordinate: true,
 		//if true lat-lng instead of lng-lat label ordering is used
 		useLatLngOrder: false,
 		//if true user given coordinates are centered directly
@@ -256,10 +258,12 @@ L.Control.Coordinates = L.Control.extend({
 	 *	Mousemove callback function updating labels and input elements
 	 */
 	_update: function(evt) {
-		var pos = evt.latlng,
-			opts = this.options;
+		var pos = evt.latlng;
 		if (pos) {
-			pos = pos.wrap();
+			var opts = this.options;
+			if(opts.wrapCoordinate || opts.useDMS) {
+				pos = pos.wrap();
+			}
 			this._currentPos = pos;
 			this._inputY.value = L.NumberFormatter.round(pos.lat, opts.decimals, opts.decimalSeperator);
 			this._inputX.value = L.NumberFormatter.round(pos.lng, opts.decimals, opts.decimalSeperator);

--- a/src/Control.Coordinates.js
+++ b/src/Control.Coordinates.js
@@ -19,6 +19,8 @@ L.Control.Coordinates = L.Control.extend({
 		enableUserInput: true,
 		//use Degree-Minute-Second
 		useDMS: false,
+		//should coordinate be wrapped as on earth
+		wrapCoordinate: true,
 		//if true lat-lng instead of lng-lat label ordering is used
 		useLatLngOrder: false,
 		//if true user given coordinates are centered directly
@@ -256,10 +258,12 @@ L.Control.Coordinates = L.Control.extend({
 	 *	Mousemove callback function updating labels and input elements
 	 */
 	_update: function(evt) {
-		var pos = evt.latlng,
-			opts = this.options;
+		var pos = evt.latlng;
 		if (pos) {
-			pos = pos.wrap();
+			var opts = this.options;
+			if(opts.wrapCoordinate || opts.useDMS) {
+				pos = pos.wrap();
+			}
 			this._currentPos = pos;
 			this._inputY.value = L.NumberFormatter.round(pos.lat, opts.decimals, opts.decimalSeperator);
 			this._inputX.value = L.NumberFormatter.round(pos.lng, opts.decimals, opts.decimalSeperator);


### PR DESCRIPTION
Add option `wrapCoordinate`, default `true`, which is the old behavior.
Coordinate wrapping can be disabled only when `useDMS` is set to `false`.

Disabling coordinate wrapping is useful for maps that uses a simple CRS, for example https://leafletjs.com/examples/crs-simple/crs-simple.html